### PR TITLE
Added automatic code formatting on commit via prettier

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+npx lint-staged

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,20 @@
+{
+  "arrowParens": "always",
+  "bracketSameLine": false,
+  "bracketSpacing": true,
+  "embeddedLanguageFormatting": "auto",
+  "endOfLine": "lf",
+  "htmlWhitespaceSensitivity": "css",
+  "insertPragma": false,
+  "jsxBracketSameLine": false,
+  "jsxSingleQuote": false,
+  "printWidth": 120,
+  "proseWrap": "preserve",
+  "quoteProps": "as-needed",
+  "requirePragma": false,
+  "semi": true,
+  "singleQuote": false,
+  "tabWidth": 2,
+  "trailingComma": "es5",
+  "useTabs": false
+}

--- a/package.json
+++ b/package.json
@@ -10,5 +10,16 @@
     "ebs",
     "frontend",
     "common"
-  ]
+  ],
+  "devDependencies": {
+    "husky": "^9.0.11",
+    "lint-staged": "^15.2.5",
+    "prettier": "^3.3.1"
+  },
+  "scripts": {
+    "prepare": "husky"
+  },
+  "lint-staged": {
+    "**/*.{ts,tsx,js,jsx,json,css,html,yaml,yml}": "prettier -w"
+  }
 }


### PR DESCRIPTION
This PR adds a pre-commit hook using `husky` which executes `prettier` on all changed files (determined by `lint-staged`).

If you don't like the `.prettierrc` settings feel free to tweak them. These are the default settings except the `printWidth` which i increased from 80 to 120

After merging the PR i recommend running `npx prettier -w .` in the repo root to format all files for the first time.