### PR TITLE
Fix Docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+services:
+  ebs:
+    build: ebs
+    restart: unless-stopped
+    ports:
+      - 3000:3000

--- a/ebs/Dockerfile
+++ b/ebs/Dockerfile
@@ -2,12 +2,8 @@ FROM node:20-alpine
 
 WORKDIR /app
 
-COPY package.json /app
-
-RUN npm install
-
-COPY . /app
+COPY dist/index.js .
 
 EXPOSE 3000
 
-CMD ["npm", "start"]
+CMD ["node", "--enable-source-maps", "index.js"]

--- a/ebs/package.json
+++ b/ebs/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "start": "npx tsx watch src/index.ts"
+    "start": "npx tsx watch src/index.ts",
+    "bundle": "esbuild --bundle --minify --platform=node --sourcemap=inline --outfile=dist/index.js src/index.ts"
   },
   "dependencies": {
     "@twurple/api": "^7.1.0",
@@ -23,6 +24,7 @@
     "@types/express": "^4.17.21",
     "@types/jsonpack": "^1.1.6",
     "@types/jsonwebtoken": "^9.0.6",
+    "esbuild": "^0.21.4",
     "tsx": "^4.11.2",
     "typescript": "^5.4.5"
   }


### PR DESCRIPTION
This PR adds esbuild to the ebs and fixes the docker stuff

To build the docker image you first need to bundle the server files by executing `npm run bundle` in the ebs directory