### PR TITLE
fix grid layout

### DIFF
--- a/frontend/www/css/redeems.css
+++ b/frontend/www/css/redeems.css
@@ -3,7 +3,7 @@
     width: calc(100% - 20px);
     margin: 10px;
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
     grid-gap: 10px;
 }
 


### PR DESCRIPTION
reduced the min. size for items and this is probably the lowest we can go because it'll start to look scuffed

![image](https://github.com/VedalAI/swarm-control/assets/71086259/58cb8359-08c4-44a8-80e4-60dfc2687f52)

it still occurs if the browser viewport is small though